### PR TITLE
Sfx mute

### DIFF
--- a/src/helpers/googleFont.ts
+++ b/src/helpers/googleFont.ts
@@ -30,8 +30,10 @@ export const webFontLoader = () => {
 export enum IconEnum {
   SETTINGS = '\ue8b8',
   FULLSCREEN = '\ue5d0',
-  SOUNDON = '\ue050',
-  SOUNDOFF = '\ue04f',
+  SFXON = '\ue050',
+  SFXOFF = '\ue04f',
+  MUSICON = '\ue405',
+  MUSICOFF = '\ue440',
   REFRESH = '\ue5d5',
   CLOSE = '\ue5cd',
   EYEOPEN = '\ue8f4',

--- a/src/helpers/settingsMenu.ts
+++ b/src/helpers/settingsMenu.ts
@@ -1,10 +1,11 @@
 import { IconEnum } from '@/helpers/googleFont';
 import iconButton from '@/helpers/iconButton';
 import fullscreenAndLandscape from '@/helpers/fullscreen';
+import GameScene from '@/scenes/game-scene';
 import useLocalStorage from './useLocalStorage';
 import isDev from './isDev';
 
-const settingsMenu = (scene: Phaser.Scene) => {
+const settingsMenu = (scene: GameScene) => {
   const { width } = scene.sys.game.canvas;
 
   let isOpen = false;
@@ -15,26 +16,44 @@ const settingsMenu = (scene: Phaser.Scene) => {
   });
   refresh.visible = false;
 
-  const [isMute] = useLocalStorage('isMute', false);
-  const soundToggle = iconButton(scene, width - 48, 48 * 5, {
-    icon: isMute ? IconEnum.SOUNDOFF : IconEnum.SOUNDON,
+  const [isSFXMute] = useLocalStorage('isSFXMute', false);
+  const sfxToggle = iconButton(scene, width - 48, 48 * 5, {
+    icon: isSFXMute ? IconEnum.SFXOFF : IconEnum.SFXON,
     onClick: () => {
-      const [isMute, setIsMute] = useLocalStorage('isMute', false);
-      const newIsMute = !isMute;
-      setIsMute(newIsMute);
-      scene.game.sound.mute = newIsMute;
-      soundToggle.setText(newIsMute ? IconEnum.SOUNDOFF : IconEnum.SOUNDON);
+      const [isSFXMute, setIsSFXMute] = useLocalStorage('isSFXMute', false);
+      const newSfxIsMute = !isSFXMute;
+      setIsSFXMute(newSfxIsMute);
+      scene.audio?.setSFXMute(newSfxIsMute);
+      sfxToggle.setText(newSfxIsMute ? IconEnum.SFXOFF : IconEnum.SFXON);
     },
   });
-  soundToggle.visible = false;
+  sfxToggle.visible = false;
 
-  const fullscreen = iconButton(scene, width - 48, 48 * 7, {
+  const [isMusicMute] = useLocalStorage('isMusicMute', false);
+  const musicToggle = iconButton(scene, width - 48, 48 * 7, {
+    icon: isMusicMute ? IconEnum.MUSICOFF : IconEnum.MUSICON,
+    onClick: () => {
+      const [isMusicMute, setIsMusicMute] = useLocalStorage(
+        'isMusicMute',
+        false,
+      );
+      const newIsMusicMute = !isMusicMute;
+      setIsMusicMute(newIsMusicMute);
+      scene.audio?.setMusicMute(newIsMusicMute);
+      musicToggle.setText(
+        newIsMusicMute ? IconEnum.MUSICOFF : IconEnum.MUSICON,
+      );
+    },
+  });
+  musicToggle.visible = false;
+
+  const fullscreen = iconButton(scene, width - 48, 48 * 9, {
     icon: IconEnum.FULLSCREEN,
     onClick: fullscreenAndLandscape,
   });
   fullscreen.visible = false;
 
-  const toggleDebugShapes = iconButton(scene, width - 48, 48 * 9, {
+  const toggleDebugShapes = iconButton(scene, width - 48, 48 * 11, {
     icon: IconEnum.EYEOPEN,
     onClick: () => {
       const oldDrawDebug = scene.matter.world.drawDebug;
@@ -51,14 +70,16 @@ const settingsMenu = (scene: Phaser.Scene) => {
 
   const open = () => {
     refresh.visible = true;
-    soundToggle.visible = true;
+    sfxToggle.visible = true;
+    musicToggle.visible = true;
     fullscreen.visible = true;
     if (isDev) toggleDebugShapes.visible = true;
   };
 
   const close = () => {
     refresh.visible = false;
-    soundToggle.visible = false;
+    sfxToggle.visible = false;
+    musicToggle.visible = false;
     fullscreen.visible = false;
     toggleDebugShapes.visible = false;
   };

--- a/src/helpers/settingsMenu.ts
+++ b/src/helpers/settingsMenu.ts
@@ -1,11 +1,11 @@
 import { IconEnum } from '@/helpers/googleFont';
 import iconButton from '@/helpers/iconButton';
 import fullscreenAndLandscape from '@/helpers/fullscreen';
-import GameScene from '@/scenes/game-scene';
+import Audio from '@/objects/Audio';
 import useLocalStorage from './useLocalStorage';
 import isDev from './isDev';
 
-const settingsMenu = (scene: GameScene) => {
+const settingsMenu = (scene: Phaser.Scene & { audio?: Audio }) => {
   const { width } = scene.sys.game.canvas;
 
   let isOpen = false;

--- a/src/objects/Audio.ts
+++ b/src/objects/Audio.ts
@@ -6,6 +6,7 @@ type AudioConfigType = {
   loop: boolean;
   volume?: number;
   soundConfig?: Phaser.Types.Sound.SoundConfig;
+  isMusic?: boolean;
 };
 
 class Audio {
@@ -34,6 +35,22 @@ class Audio {
       const config: AudioConfigType = configs[i];
       scene.load.audio(config.key, config.filePath);
     }
+  }
+
+  setSFXMute(mute: boolean) {
+    Object.entries(this.audioConfig).forEach(([key, config]) => {
+      if (!config.isMusic || config.isMusic === undefined) {
+        this.audio[key].setMute(mute);
+      }
+    });
+  }
+
+  setMusicMute(mute: boolean) {
+    Object.entries(this.audioConfig).forEach(([key, config]) => {
+      if (config.isMusic) {
+        this.audio[key].setMute(mute);
+      }
+    });
   }
 
   playAudio(key: string) {

--- a/src/scenes/game-scene.ts
+++ b/src/scenes/game-scene.ts
@@ -98,16 +98,19 @@ const soundConfig = [
     key: 'music1',
     filePath: './audio/music/fluffing-a-duck.mp3',
     loop: true,
+    isMusic: true,
   },
   {
     key: 'music2',
     filePath: './audio/music/sneaky-snitch.mp3',
     loop: true,
+    isMusic: true,
   },
   {
     key: 'music3',
     filePath: './audio/music/spook.mp3',
     loop: true,
+    isMusic: true,
   },
   {
     key: 'jump',
@@ -157,8 +160,6 @@ class GameScene extends Phaser.Scene {
     this.audio = new Audio(this, soundConfig);
 
     this.audio.playAudio('music1');
-    const [isMute] = useLocalStorage('isMute', false);
-    this.game.sound.mute = isMute; // set game mute to saved ls value
 
     this.player = this.level.spawners.player.getChildren()[0] as Ben3;
     this.goal = this.level.spawners.goal.getChildren()[0] as Skull;
@@ -173,6 +174,12 @@ class GameScene extends Phaser.Scene {
 
     this.score = new Text(this, 10, 10);
     this.coins = new Text(this, 10, 30);
+
+    // set sfx/music mute from local storage
+    const [isSFXMute] = useLocalStorage('isSFXMute', false);
+    this.audio?.setSFXMute(isSFXMute);
+    const [isMusicMute] = useLocalStorage('isMusicMute', false);
+    this.audio?.setMusicMute(isMusicMute);
 
     settingsMenu(this);
   }


### PR DESCRIPTION
Added icons for music/sfx mute.
added audioConfig option isMusic so we know is the loaded sound is music.
Added `setSFXMute()` and `setMusicMute()` to Audio class so we can toggle either music or SFX based off the isMusic param from audioConfig. 