### PR TITLE
remove eye icon on prod build

### DIFF
--- a/src/overlays/SettingHud.ts
+++ b/src/overlays/SettingHud.ts
@@ -46,7 +46,7 @@ const buttonConfig = [
         {
           buttonName: 'isDebugOn',
           icons: [IconEnum.EYEOPEN, IconEnum.EYECLOSED],
-          allowVisibilityChange: isDev,
+          allowVisibilityChange: true,
         },
       ]
     : []),

--- a/src/overlays/SettingHud.ts
+++ b/src/overlays/SettingHud.ts
@@ -41,11 +41,15 @@ const buttonConfig = [
     icons: [IconEnum.FULLSCREENON, IconEnum.FULLSCREENOFF],
     allowVisibilityChange: true,
   },
-  {
-    buttonName: 'isDebugOn',
-    icons: [IconEnum.EYEOPEN, IconEnum.EYECLOSED],
-    allowVisibilityChange: isDev,
-  },
+  ...(isDev
+    ? [
+        {
+          buttonName: 'isDebugOn',
+          icons: [IconEnum.EYEOPEN, IconEnum.EYECLOSED],
+          allowVisibilityChange: isDev,
+        },
+      ]
+    : []),
 ];
 
 type RegistryItem = {


### PR DESCRIPTION
remove the EYE icon that was accidentally added in #34 


![Screenshot from 2023-11-28 08-40-27](https://github.com/ScottyXIII/bigheaded/assets/4681349/d9cbdf25-9747-4e0b-b4d0-ebcaec5ae2a6)

