### PR TITLE
deadzone - hardcoded?

### DIFF
--- a/src/helpers/touchEvents.ts
+++ b/src/helpers/touchEvents.ts
@@ -3,10 +3,11 @@ const touchEvents = (scene: Phaser.Scene) => {
   const { width } = scene.sys.game.canvas;
   const halfWidth = width / 2; // half screen.
   const quarterWidth = width / 4; // quarter screen.
+  const deadZone = width - 100;
 
   if (pointer.isDown) {
     // right half of screen touch
-    if (pointer.x > halfWidth) {
+    if (pointer.x > halfWidth && pointer.x < deadZone) {
       scene.events.emit('touch-right');
       return;
     }


### PR DESCRIPTION
dead zone so we don't trigger a jump when pushing settings buttons on the side.
Hard coded to 100px. I think the buttons are 48*2=96px in with. 
Dead zone rounded up to 100px. 